### PR TITLE
22 [subtitle-event]: add tests for SSASubtitleEvent

### DIFF
--- a/src/__tests__/subtitle-event.test.js
+++ b/src/__tests__/subtitle-event.test.js
@@ -41,8 +41,8 @@ describe("SSASubtitleEvent", () => {
     describe("#setLineTransitionTargetOverrides / getLineTransitionTargetOverrides", () => {
         const lineOverrides = 'lineOverrides';
 
-        it("should return undefined if line overrides is not defined", () => {
-            expect(subtitleEvent.getLineTransitionTargetOverrides()).toBeUndefined();
+        it("should return null if line overrides is not defined", () => {
+            expect(subtitleEvent.getLineTransitionTargetOverrides()).toBeNull();
         });
 
         it("should be able to set and get line overrides", () => {


### PR DESCRIPTION
**Important:** this PR depends on #28 PR since it is used its `src/__tests__/test-utils/primitive-values-methods.utils.js`. The PR can be merged only after #28.

Issue: #22

Changes: create test file for subtitle-event.js

Results:
Count of tests: 19
![image](https://user-images.githubusercontent.com/15786916/136693580-5990f050-de6c-4c8f-8edf-191a5f6f47c1.png)
