### PR TITLE
Fix for incorrectly implemented fade tag.

### DIFF
--- a/src/__tests__/testfiles/tag_tests.ass
+++ b/src/__tests__/testfiles/tag_tests.ass
@@ -33,7 +33,7 @@ Dialogue: 0,0:00:17.00,0:00:22.00,Default,,0,0,0,,{\3c&H808080&}This file tests 
 Dialogue: 0,0:00:18.00,0:00:23.00,Default,,0,0,0,,{\4c&H808080&}This file tests Advanced Substation Alpha parsing.
 Dialogue: 0,0:00:19.00,0:00:24.00,Default,,0,0,0,,{\clip(0,0,100,101)}This file tests Advanced Substation Alpha parsing.
 Dialogue: 0,0:00:20.00,0:00:25.00,Default,,0,0,0,,{\clip(1,m 0 0 l 100 0 100 101 0 101)}This file tests Advanced Substation Alpha parsing.
-Dialogue: 0,0:00:21.00,0:00:26.00,Default,,0,0,0,,{\fade(0,255,0,0,1250,1250,0)}This file tests Advanced Substation Alpha parsing.
+Dialogue: 0,0:00:21.00,0:00:26.00,Default,,0,0,0,,{\fade(0,255,0,0,1250,3750,5000)}This file tests Advanced Substation Alpha parsing.
 Dialogue: 0,0:00:22.00,0:00:27.00,Default,,0,0,0,,{\fad(1250,1250)}This file tests Advanced Substation Alpha parsing.
 Dialogue: 0,0:00:23.00,0:00:28.00,Default,,0,0,0,,{\fax5}This file tests Advanced Substation Alpha parsing.
 Dialogue: 0,0:00:24.00,0:00:29.00,Default,,0,0,0,,{\fay5}This file tests Advanced Substation Alpha parsing.

--- a/src/subtitle-parser.js
+++ b/src/subtitle-parser.js
@@ -1659,10 +1659,10 @@ const parser_prototype = global.Object.create(global.Object, {
                         isNaN(t4)
                     )
                         return;
-                    t1 = timeInfo.start + (t1 / 1000);
-                    t2 = timeInfo.start + (t2 / 1000);
-                    t3 = timeInfo.end - (t3 / 1000);
-                    t4 = timeInfo.end - (t4 / 1000);
+                    t1 = timeInfo.start + t1 / 1000;
+                    t2 = timeInfo.start + t2 / 1000;
+                    t3 = timeInfo.start + t3 / 1000;
+                    t4 = timeInfo.start + t4 / 1000;
                     lineGlobalOverrides.setFade(
                         1 - (a1 & 0xff) / 255,
                         1 - (a2 & 0xff) / 255,
@@ -3035,7 +3035,7 @@ const parser_prototype = global.Object.create(global.Object, {
             this._config = /** @type {RendererData} */ ({
                 "info": {},
                 "parser": {},
-                "renderer": {"default_wrap_style": sabre.WrapStyleModes.SMART}
+                "renderer": { "default_wrap_style": sabre.WrapStyleModes.SMART }
             });
             if (subsText.indexOf("\xEF\xBB\xBF") === 0) {
                 //check for BOM


### PR DESCRIPTION
Fix the incorrectly implemented ``\fade(<a1>,<a2>,<a3>,<t1>,<t2>,<t3>,<t4>)`` tag so that complex fades work correctly.