### PR TITLE
Fix a minor typo.

### DIFF
--- a/gallery/but_i_use_safari.md
+++ b/gallery/but_i_use_safari.md
@@ -1,4 +1,4 @@
-# Gallery of Screnshots
+# Gallery of Screenshots
 
 ## "BuT I UsE SaFaRi" edition
 

--- a/gallery/gallery.md
+++ b/gallery/gallery.md
@@ -1,4 +1,4 @@
-# Gallery of Screnshots
+# Gallery of Screenshots
 
 ### 12/30/2021 - Subtitle Output Achieved!
 


### PR DESCRIPTION
Fix a typo in the gallery where it said "screnshots" instead of "screenshots".