### PR TITLE
Fixed spaces in path, fixed a issue with shader.js

### DIFF
--- a/scripts/helpers/execute-java.sh
+++ b/scripts/helpers/execute-java.sh
@@ -6,8 +6,8 @@ IKVM_DOWNLOAD_URL="http://www.frijters.net/ikvmbin-8.1.5717.0.zip"
 USED_JVM="java"
 JVM_SETTINGS="-server -XX:+TieredCompilation"
 
-BACKUP_PATH=$PATH
-export PATH=$PATH:$TOOL_BIN_DIR
+BACKUP_PATH="$PATH"
+export PATH="$PATH:$TOOL_BIN_DIR"
 
 if [ -x "$(command -v ikvm)" ]; then
     USED_JVM="ikvm"
@@ -40,5 +40,5 @@ fi
 eval "$USED_JVM $JVM_SETTINGS $@"
 RESULT_CODE=$?
 
-export PATH=$BACKUP_PATH
+export PATH="$BACKUP_PATH"
 exit $RESULT_CODE

--- a/src/shader.js
+++ b/src/shader.js
@@ -59,7 +59,6 @@ const ShaderPrototype = Object.create(Object, {
             let cval = statetracker[context][uniformid];
             let i;
             let unchanged = true;
-            if (val === cval) return true;
             if (isArrayish(val) && isArrayish(cval)) {
                 if (val.length !== cval.length) return false;
                 else
@@ -69,6 +68,7 @@ const ShaderPrototype = Object.create(Object, {
 
                 return unchanged;
             }
+            if (val === cval) return true;
             return false;
         },
         writable: false


### PR DESCRIPTION
Spaces in the path would cause issues with execute-java.sh.
shader.js had a condition in the wrong order.