### PR TITLE
Fixes for clip animation and animation related performance.

### DIFF
--- a/src/renderer-main.js
+++ b/src/renderer-main.js
@@ -546,7 +546,8 @@ const renderer_prototype = global.Object.create(Object, {
                 if (
                     events[i].getLineOverrides().hasMovement() ||
                     events[i].getLineOverrides().getFade() !== null ||
-                    events[i].getLineTransitionTargetOverrides() !== null ||
+                    (events[i].getLineTransitionTargetOverrides() !== null &&
+                    events[i].getLineTransitionTargetOverrides().length > 0) ||
                     events[i].getOverrides().getKaraokeMode() !==
                         sabre.KaraokeModes.OFF ||
                     events[i].getOverrides().getTransitions().length > 0
@@ -3070,7 +3071,7 @@ const renderer_prototype = global.Object.create(Object, {
                         ].getTransitionAcceleration();
                     clip[0] = sabre.performTransition(
                         time,
-                        /** @type {number} */ (clip[0]),
+                        /** @type {!number} */ (clip[0]),
                         transitionClip[0],
                         transitionStart,
                         transitionEnd,
@@ -3078,7 +3079,7 @@ const renderer_prototype = global.Object.create(Object, {
                     );
                     clip[1] = sabre.performTransition(
                         time,
-                        /** @type {number} */ (clip[1]),
+                        /** @type {!number} */ (clip[1]),
                         transitionClip[1],
                         transitionStart,
                         transitionEnd,
@@ -3086,7 +3087,7 @@ const renderer_prototype = global.Object.create(Object, {
                     );
                     clip[2] = sabre.performTransition(
                         time,
-                        /** @type {number} */ (clip[2]),
+                        /** @type {!number} */ (clip[2]),
                         transitionClip[2],
                         transitionStart,
                         transitionEnd,
@@ -3094,7 +3095,7 @@ const renderer_prototype = global.Object.create(Object, {
                     );
                     clip[3] = sabre.performTransition(
                         time,
-                        /** @type {number} */ (clip[3]),
+                        /** @type {!number} */ (clip[3]),
                         transitionClip[3],
                         transitionStart,
                         transitionEnd,

--- a/src/subtitle-event.js
+++ b/src/subtitle-event.js
@@ -218,7 +218,7 @@ sabre["SSASubtitleEvent"] = function SSASubtitleEvent () {
 
         "getLineTransitionTargetOverrides": {
             value: function getLineTransitionTargetOverrides () {
-                return obj.lineTransitionTargetOverrides.slice(0);
+                return obj.lineTransitionTargetOverrides;
             },
             writable: false
         }


### PR DESCRIPTION
 - Fixed a oversight with regard to detecting animations that resulted in animations being detected in most cases when there were none; hurting performance.
 - Fixed subtitle event to just store the lineGlobalTransitionTargetOverrides instead of cloning them on fetch. This fixes clip animation via the transition tag.
 